### PR TITLE
pinned cloudpickle dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         zip_safe=False,
 
         install_requires=[
-            'cloudpickle>=0.2.1',
+            'cloudpickle==0.2.1',
         ],
         extras_require=dict(
             dev=[


### PR DESCRIPTION
By default cloudpickle 0.4 is installed this leads to the following error:

```
from cycloudpickle.cycloudpickle import *
  File "cycloudpickle/cycloudpickle.pyx", line 63, in init cycloudpickle.cycloudpickle (cycloudpickle/cycloudpickle.c:16552)
ImportError: cannot import name _reconstruct_closure
```

This pins this dependency to version 0.2.1 which seems to work.